### PR TITLE
Fixed bug for major-mode segment

### DIFF
--- a/simple-modeline-segments.el
+++ b/simple-modeline-segments.el
@@ -196,7 +196,7 @@ corresponding to the mode line clicked."
   (concat " "
           (or (and (boundp 'delighted-modes)
                    (cadr (assq major-mode delighted-modes)))
-              mode-name))
+              (format-mode-line mode-name)))
   'face 'bold))
 
 (provide 'simple-modeline-segments)


### PR DESCRIPTION
Some mode-names are actually constructs for mode-line-format. This
means we need to get a string we have to call "format-mode-line"

This should close issue #2