### PR TITLE
Fix simple-modline--format in olivetti-mode

### DIFF
--- a/simple-modeline-core.el
+++ b/simple-modeline-core.el
@@ -94,7 +94,9 @@
     (concat
      left
      (propertize " "
-                 'display `((space :align-to (- right ,reserve)))
+                 'display `((space :align-to (- right 
+                                                (- 0 right-margin)
+                                                ,reserve)))
                  'face '(:inherit simple-modeline-space))
      right)))
 


### PR DESCRIPTION
`olivetti-mode` adjusts the window margin, which pushes the right segment of the modeline with simple-modeline to the left.  At least for me.

After a little experimentation I've found that adding `(- 0 right-margin)` to the `simple-modeline--format` function adjusts the spacing for `olivetti-mode`.

I tried `(- right-margin)` but that doesn't work for some reason.  I've also done very minimal testing, so it might not work everywhere.